### PR TITLE
Dashboard auth

### DIFF
--- a/data/pg_example.js
+++ b/data/pg_example.js
@@ -1,0 +1,52 @@
+const { Pool, Client } = require('pg')
+
+var connectionString = "postgres://postgres:@localhost:5432/myhealthapp";
+
+// create a pool
+// const pool = new Pool({
+//     user: 'postgres',
+//     host: 'localhost',
+//     database: 'myhealthapp',
+//     password: '',
+//     port: 5432,
+// })
+
+const pool = new Pool({ connectionString: connectionString })
+
+const query = `
+select sub.okdate, count(sub.okdate) 
+  from (select id,date_trunc('day',updated_at) as okdate 
+    from authorizations 
+    where (status='AUTORIZADO' or status='AUTORIZADO AUTOMATICAMENTE') 
+    and updated_at > now() - interval '30 days') 
+  as sub 
+  group by sub.okdate 
+  order by sub.okdate asc;
+`
+
+new Promise((resolve, reject) => {
+    pool.query(query, (err, res) => {
+        if (err) reject(err)
+        else resolve(res.rows)
+    })
+}).then(rows => {
+    console.log({ rows })
+}).catch(err => {
+    console.error({ err })
+}).finally(() => pool.end())
+
+const client = new Client({
+    connectionString: connectionString,
+});
+
+
+client.connect().then(() => {
+    client.query('SELECT NOW()', (err, resultset) => {
+        throw  new Error("Un error loco");
+        // console.log(err, resultset.rows)
+        // client.end()
+    })
+}).catch(err => {
+    console.log("CAPTURADO")
+    console.log(err.message)
+})

--- a/routes/dashboards.js
+++ b/routes/dashboards.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const router = express.Router();
+const config = require('../config')
+const configEnv = config[process.env.NODE_ENV]
+const { Client } = require('pg')
+
+
+const db_uri = configEnv['DB_URI']
+
+function runQuery(query, res) {
+    const client = new Client({ connectionString: db_uri })
+
+    function handleError(err) {
+        res.status(500).json({ error: `Ocurrio un error al obtener conteo de autorizaciones > ${err.message}` })
+    }
+
+    client.connect().then(() => {
+        client.query(query, (err, resultset) => {
+            if (err) handleError(err)
+            else res.json(resultset.rows)
+            client.end()
+        })
+    }).catch(handleError)
+}
+
+router.get('/auth/authorized', (_, res) => {
+    const query = `
+    select sub.okdate, count(sub.okdate) 
+      from (select id,date_trunc('day',updated_at) as okdate 
+        from authorizations 
+        where (status='AUTORIZADO' or status='AUTORIZADO AUTOMATICAMENTE') 
+        and updated_at > now() - interval '30 days') 
+      as sub 
+      group by sub.okdate 
+      order by sub.okdate asc;
+    `
+
+    runQuery(query, res);
+})
+
+
+router.get('/auth/rejected', (_, res) => {
+    const query = `
+    select sub.okdate, count(sub.okdate) 
+      from (select id,date_trunc('day',updated_at) as okdate 
+        from authorizations 
+        where status='RECHAZADO' 
+        and updated_at > now() - interval '30 days') 
+      as sub 
+      group by sub.okdate 
+      order by sub.okdate asc;
+    `
+
+    runQuery(query, res);
+})
+
+module.exports = router

--- a/routes/dashboards.js
+++ b/routes/dashboards.js
@@ -54,4 +54,32 @@ router.get('/auth/rejected', (_, res) => {
     runQuery(query, res);
 })
 
+router.get('/auth/pending', (_, res) => {
+    const query = `
+    select sub.okdate, count(sub.okdate) 
+      from (select id,date_trunc('day',updated_at) as okdate 
+        from authorizations 
+        where status='PENDIENTE' 
+        and updated_at > now() - interval '30 days') 
+      as sub 
+      group by sub.okdate 
+      order by sub.okdate asc;
+    `
+
+    runQuery(query, res);
+})
+
+
+router.get('/auth/summary', (_,res) => {
+    const query = `
+    select count(distinct id) , status from authorizations 
+        where status='AUTORIZADO' or status='AUTORIZADO AUTOMATICAMENTE' 
+        and updated_at > now() - interval '30 days'
+        group by status
+    `
+
+    runQuery(query, res);
+})
+
+
 module.exports = router

--- a/routes/dashboards.js
+++ b/routes/dashboards.js
@@ -73,9 +73,8 @@ router.get('/auth/pending', (_, res) => {
 router.get('/auth/summary', (_,res) => {
     const query = `
     select count(distinct id) , status from authorizations 
-        where status='AUTORIZADO' or status='AUTORIZADO AUTOMATICAMENTE' 
-        and updated_at > now() - interval '30 days'
-        group by status
+        where updated_at > now() - interval '30 days'
+        group by status;
     `
 
     runQuery(query, res);

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ const zones = require('./zones')
 const lenders = require('./lenders')
 const authorizations = require('./authorizations')
 const authtypes = require('./authtypes')
+const dashboards = require('./dashboards')
 
 module.exports = api => {
 
@@ -14,5 +15,6 @@ module.exports = api => {
     api.use('/lenders', lenders)
     api.use('/authorizations', authorizations)
     api.use('/authtypes', authtypes)
+    api.use('/dashboards', dashboards)
     return api
 }


### PR DESCRIPTION
Se desarrollaron los endpoints necesarios para dibujar el grafico de linea de autorizaciones en el dashboard

Endpoints:
* /auth/authorized : devuelve cantidad de autorizaciones aprobadas por dia.
  - Ejemplo respuesta: `[{"okdate":"2019-11-14T00:00:00.000Z","count":"1"},{"okdate":"2019-11-16T00:00:00.000Z","count":"1"},{"okdate":"2019-11-18T00:00:00.000Z","count":"2"}]`
* /auth/rejected : devuelve cantidad de autorizaciones rechazadas por dia.
  - Ejemplo respuesta: `[{"okdate":"2019-11-14T00:00:00.000Z","count":"1"}]`
* /auth/summary : devuelve un resumen de conteo de autorizaciones por estado

Estos tres endpoints trabajan con registros de los __ultimos 30 dias__

